### PR TITLE
Implementation of Inverse Transform at Inference Step

### DIFF
--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -70,9 +70,8 @@ def main():
     task = EnergyReconstruction(
         hidden_size=gnn.nb_outputs,
         target_label=target,
-        loss_function=LogCoshLoss(
-            transform_prediction_and_target=torch.log10,
-        ),
+        loss_function=LogCoshLoss,
+        transform_prediction_and_target=torch.log10,
     )
     model = Model(
         detector=detector,

--- a/misc/badges/pylint.svg
+++ b/misc/badges/pylint.svg
@@ -17,7 +17,7 @@
         <text x="22.0" y="14">pylint</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">6.51</text>
-        <text x="62.0" y="14">6.51</text>
+        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">7.04</text>
+        <text x="62.0" y="14">7.04</text>
     </g>
 </svg>

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -132,3 +132,8 @@ class Model(LightningModule):
 
     def _get_batch_size(self, data: Data) -> int:
         return torch.numel(torch.unique(data.batch))
+
+    def inference(self):
+        """Sets model to inference mode."""
+        for task in self._tasks:
+            task.inference()

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -110,6 +110,9 @@ def get_predictions(trainer, model, dataloader, prediction_columns, additional_a
         additional_attributes = []
     assert isinstance(additional_attributes, list)
 
+    # Set model to inference mode
+    model.inference()
+
     # Get predictions
     predictions_torch = trainer.predict(model, dataloader)
     predictions = [p[0].detach().cpu().numpy() for p in predictions_torch]  # Assuming single task


### PR DESCRIPTION
Implements Inverse Transformation by passing the transformation functions (e.g. `transform_prediction_and_target`) to the task instead of the loss function, and passing the not-instanced loss function class to the task function as shown in the training example (line 43). 

The task then instances the loss function with the proper transformation functions, but remembers the inference transformation for later use (task, line 47). The forward method of the task includes a transformation (line 58), which is initially set to a unit transformation (line 49).

In the `get_predictions.py` the model is set to inference mode, which simple calls a similar method for the task (model, line 136) which subsitutes the forward transformation for the inference function (task, line 71).

This way, it is only nessecary to specify the transformation functions in one place (when creating the task), and the framework will make sure to accept only `transform_prediction_and_target` or both `transform_inference` and `transform_target` or none of them.