### PR TITLE
Only commit badges on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push
+  # Triggers the workflow on push and PRs
   push:
     paths-ignore: [ misc/badges/ ]
   pull_request:
@@ -47,6 +47,9 @@ jobs:
           git config user.name "Andreas Søgaard"
           git status
       - name: Stage badges
-        run: git add -f misc/badges/
+        run: |
+          git add -f misc/badges/
       - name: Commit and push changes
-        run: git commit -m "Auto-updating coverage badge" > /dev/null && git push origin ${GITHUB_REF##*/} || echo "Nothing to push"
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git commit -m "Auto-updating coverage badge" > /dev/null && git push origin ${GITHUB_REF##*/} || echo "Nothing to push"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push events
+  # Triggers the workflow on push and PRs
   push:
     paths-ignore: [ misc/badges/ ]
   pull_request:
@@ -45,5 +45,6 @@ jobs:
         run: |
           git add -f misc/badges/
       - name: Commit and push changes
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git commit -m "Auto-updating lint badge" > /dev/null && git push origin ${GITHUB_REF##*/} || echo "Nothing to push"

--- a/misc/badges/pylint.svg
+++ b/misc/badges/pylint.svg
@@ -17,7 +17,7 @@
         <text x="22.0" y="14">pylint</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">7.33</text>
-        <text x="62.0" y="14">7.33</text>
+        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">6.97</text>
+        <text x="62.0" y="14">6.97</text>
     </g>
 </svg>


### PR DESCRIPTION
This means that badges are not auto-updated on pushes to non-main branches, i.e. they are only updated once they are about to go into the main branch. This should hopefully reduce the frequency of related merge conflicts from diverging lint and coverage scores.

cc @kaareendrup 