### PR TITLE
added data-object and target_label as input to loss functions

### DIFF
--- a/src/graphnet/components/loss_functions.py
+++ b/src/graphnet/components/loss_functions.py
@@ -258,8 +258,20 @@ class VonMisesFisher2DLoss(VonMisesFisherLoss):
 
         return self._evaluate(p, t)
 
-class XYZWithMaxScaling(LossFunction):
+
+class EuclideanDistance(LossFunction):
     def _forward(self, prediction: Tensor, target: Tensor, data: Data, target_label: str) -> Tensor:
-        diff = (prediction[:,0] - target[:,0]/764.431509)**2 + (prediction[:,1] - target[:,1]/785.041607)**2 + (prediction[:,2] - target[:,2]/1083.249944)**2 #+(prediction[:,3] - target[:,3]/14721.646883) 
-        elements = torch.sqrt(diff)
-        return elements
+        """Calculates the 3D Euclidean distance between predicted and target.
+
+        Args:
+            prediction (Tensor): Output of the model. Must have shape [N, 3]
+            target (Tensor): Target tensor, extracted from graph object.
+            data (Data): torch_geometric.data.Data Object.
+            target_label (str): the target name. Enables target = data[target_label] indexing
+
+        Returns:
+            Tensor: Loss. Shape [n,1]
+        """
+        return torch.sqrt((prediction[:,0] - target[:,0])**2 + (prediction[:,1] - target[:,1])**2 + (prediction[:,2] - target[:,2])**2) 
+
+

--- a/src/graphnet/models/task/reconstruction.py
+++ b/src/graphnet/models/task/reconstruction.py
@@ -34,6 +34,24 @@ class AzimuthReconstruction(AzimuthReconstructionWithKappa):
         return angle
 
 
+class PassOutput1(Task):
+    """Passes 1 output without interference."""
+    nb_inputs = 1
+    def _forward(self, x):
+        return x
+
+class PassOutput2(Task):
+    """Passes 2 output without interference."""
+    nb_inputs = 2
+    def _forward(self, x):
+        return x
+
+class PassOutput3(Task):
+    """Passes 3 output without interference."""
+    nb_inputs = 3
+    def _forward(self, x):
+        return x
+
 class ZenithReconstruction(Task):
     """Reconstructs zenith angle."""
     # Requires two features: untransformed points in (x,y)-space.
@@ -58,10 +76,10 @@ class EnergyReconstruction(Task):
     """Reconstructs energy."""
     # Requires one feature: untransformed energy
     nb_inputs = 1
-
     def _forward(self, x):
         # Transform energy
         return torch.pow(10, x[:,0] + 1.).unsqueeze(1)
+
 
 class EnergyReconstructionWithUncertainty(EnergyReconstruction):
     """Reconstructs energy and associated uncertainty (log(var))."""
@@ -86,13 +104,6 @@ class VertexReconstruction(Task):
         x[:,1] = x[:,1] * 1e2
         x[:,2] = x[:,2] * 1e2
 
-        return x 
-
-class XYZReconstruction(Task):
-    # Requires four features, x, y, z
-    nb_inputs = 3
-
-    def _forward(self, x):
         return x 
 
 class PositionReconstruction(Task):

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -105,9 +105,8 @@ class Task(LightningModule):
 
     @final
     def compute_loss(self, pred: Union[Tensor, Data], data: Data) -> Tensor:
-        target = data[self._target_label]
-        target = self._transform_target(target)
-        loss = self._loss_function(pred, target) + self._regularisation_loss
+        transformed_target = self._transform_target(data[self._target_label])
+        loss = self._loss_function(pred, transformed_target, data, self._target_label) + self._regularisation_loss
         return loss
 
     @final

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -167,39 +167,3 @@ def load_model(db, tag, archive, detector, gnn, task, device):
     model.load_state_dict(torch.load(path + '/' + tag + '.pth'))
     model.eval()
     return model
-
-class Predictor(object):
-    def __init__(self, dataloader, target, device, output_column_names, post_processing_method = None):
-        self.dataloader = dataloader
-        self.target = target
-        self.output_column_names = output_column_names
-        self.device = device
-        self.post_processing_method = post_processing_method
-
-    def __call__(self, model):
-        self.model = model
-        self.model.eval()
-        self.model.predict = True
-        if self.post_processing_method == None:
-            return self._predict()
-        else:
-            return self.post_processing_method(self._predict(), self.target)
-
-    def _predict(self):
-        assert len(self.model._tasks) == 1
-        predictions = []
-        event_nos = []
-        energies = []
-        target = []
-        with torch.no_grad():
-            for batch_of_graphs in tqdm(self.dataloader, unit = 'batches'):
-                batch_of_graphs.to(self.device)
-                target.extend(batch_of_graphs[self.target].detach().cpu().numpy())
-                predictions.extend(self.model(batch_of_graphs)[0].detach().cpu().numpy())
-                event_nos.extend(batch_of_graphs['event_no'].detach().cpu().numpy())
-                energies.extend(batch_of_graphs['energy'].detach().cpu().numpy())
-        out = pd.DataFrame(data = predictions, columns = self.output_column_names)
-        out['event_no'] = event_nos
-        out['energy'] = energies
-        out[self.target] = target
-        return out

--- a/tests/test_loss_functions.py
+++ b/tests/test_loss_functions.py
@@ -8,6 +8,7 @@ from torch.autograd import grad
 
 from graphnet.components.loss_functions import LogCoshLoss, VonMisesFisherLoss
 from graphnet.utils import eps_like
+from torch_geometric.data import Data
 
 # Utility method(s)
 def _compute_elementwise_gradient(outputs: Tensor, inputs: Tensor) -> Tensor:
@@ -39,10 +40,11 @@ def test_log_cosh(dtype=torch.float32):
     # Prepare test data
     x = torch.tensor([-100, -10, -1, 0, 1, 10, 100], dtype=dtype).unsqueeze(1)  # Shape [N, 1]
     y = 0. * x.clone().squeeze()  # Shape [N,]
-
+    data = Data(x = x)
+    data['target'] = y
     # Calculate losses using loss function, and manually
     log_cosh_loss = LogCoshLoss()
-    losses = log_cosh_loss(x, y, return_elements=True)
+    losses = log_cosh_loss(x, y, data, 'target', return_elements=True)
     losses_reference = torch.log(torch.cosh(x[:,0] - y))
 
     # (1) Loss functions should not return  `inf` losses, even for large


### PR DESCRIPTION
Hi!

This PR lets loss functions recieve the full `torch_geometric.data.Data-object` and the `target_label`.  Before, loss functions only had the prediction and the truth available.

The reason behind this proposed change is that having the full Data object available allows us to use truth variables to calculate weights inside the loss function we make.

I have updated all current loss functions such that they work with this change.

Rasmus