### PR TITLE
Ensure targets always have two dimensions

### DIFF
--- a/src/graphnet/components/loss_functions.py
+++ b/src/graphnet/components/loss_functions.py
@@ -70,8 +70,7 @@ class LogCoshLoss(LossFunction):
 
     def _forward(self, prediction: Tensor, target: Tensor) -> Tensor:
         """Implementation of loss calculation."""
-        assert prediction.dim() == target.dim() + 1
-        diff = prediction[:,0] - target
+        diff = prediction - target
         elements = self._log_cosh(diff)
         return elements
 
@@ -226,11 +225,11 @@ class VonMisesFisher2DLoss(VonMisesFisherLoss):
         """
         # Check(s)
         assert prediction.dim() == 2 and prediction.size()[1] == 2
-        assert target.dim() == 1
+        assert target.dim() == 2
         assert prediction.size()[0] == target.size()[0]
 
         # Formatting target
-        angle_true = target
+        angle_true = target[:,0]
         t = torch.stack([
             torch.cos(angle_true),
             torch.sin(angle_true),
@@ -248,6 +247,6 @@ class VonMisesFisher2DLoss(VonMisesFisherLoss):
 
 class XYZWithMaxScaling(LossFunction):
     def _forward(self, prediction: Tensor, target: Tensor) -> Tensor:
-        diff = (prediction[:,0] - target[:,0]/764.431509)**2 + (prediction[:,1] - target[:,1]/785.041607)**2 + (prediction[:,2] - target[:,2]/1083.249944)**2 #+(prediction[:,3] - target[:,3]/14721.646883) 
+        diff = (prediction[:,0] - target[:,0]/764.431509)**2 + (prediction[:,1] - target[:,1]/785.041607)**2 + (prediction[:,2] - target[:,2]/1083.249944)**2 #+(prediction[:,3] - target[:,3]/14721.646883)
         elements = torch.sqrt(diff)
         return elements

--- a/tests/test_loss_functions.py
+++ b/tests/test_loss_functions.py
@@ -38,12 +38,12 @@ def _compute_elementwise_gradient(outputs: Tensor, inputs: Tensor) -> Tensor:
 def test_log_cosh(dtype=torch.float32):
     # Prepare test data
     x = torch.tensor([-100, -10, -1, 0, 1, 10, 100], dtype=dtype).unsqueeze(1)  # Shape [N, 1]
-    y = 0. * x.clone().squeeze()  # Shape [N,]
+    y = 0. * x.clone()  # Shape [N,1]
 
     # Calculate losses using loss function, and manually
     log_cosh_loss = LogCoshLoss()
     losses = log_cosh_loss(x, y, return_elements=True)
-    losses_reference = torch.log(torch.cosh(x[:,0] - y))
+    losses_reference = torch.log(torch.cosh(x - y))
 
     # (1) Loss functions should not return  `inf` losses, even for large
     #     differences between prediction and target. This is not necessarily


### PR DESCRIPTION
Following #158 target tensors will always have two dimensions. Currently, loss functions are not accounting for this, giving rise to an assertion error when using `LogCoshLoss` in one of the example scripts, as reported by @mortenholmrep. This PR updates the loss functions use the right assumptions about target tensor dimensionality.

Closes #143 