### PR TITLE
Changing order of operations (transform/log10)

### DIFF
--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -93,8 +93,8 @@ class Task(LightningModule):
     def forward(self, x: Union[Tensor, Data]) -> Union[Tensor, Data]:
         self._regularisation_loss = 0  # Reset
         x = self._affine(x)
-        x = self._transform_prediction(x)
-        return self._forward(x)
+        x = self._forward(x)
+        return self._transform_prediction(x)
 
     @final
     def _transform_prediction(self, prediction: Union[Tensor, Data]) -> Union[Tensor, Data]:


### PR DESCRIPTION
@kaareendrup @asogaard 
Fixing energy reconstruction NaNs by first transforming then taking the log of predictions. examples/train_model now works out of the box