### PR TITLE
two changes to i3 extractor

### DIFF
--- a/src/graphnet/data/i3extractor.py
+++ b/src/graphnet/data/i3extractor.py
@@ -93,7 +93,7 @@ class I3FeatureExtractor(I3Extractor):
                     frame["I3Calibration"] = self._calibration
                     data = frame[self._pulsemap].apply(frame)
                     om_keys = data.keys()
-                    #del frame["I3Calibration"]  # Avoid modifying the frame in-place
+                    del frame["I3Calibration"]  # Avoid adding unneccesary data to frame
             except:
                 data = dataclasses.I3RecoPulseSeriesMap.from_frame(frame, self._pulsemap)
                 om_keys = data.keys()
@@ -127,10 +127,7 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
             y = self._gcd_dict[om_key].position.y
             z = self._gcd_dict[om_key].position.z
             area = self._gcd_dict[om_key].area
-            if "I3Calibration" in frame:  # Not available for e.g. mDOMs in IceCube Upgrade
-                rde = frame["I3Calibration"].dom_cal[om_key].relative_dom_eff
-            else:
-                rde = -1.
+            rde = self._get_relative_dom_efficiency(frame, om_key)
 
             # Loop over pulses for each OM
             pulses = data[om_key]
@@ -145,6 +142,15 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
                 output['dom_z'].append(z)
 
         return output
+    def _get_relative_dom_efficiency(self, frame, om_key):
+        if "I3Calibration" in frame:  # Not available for e.g. mDOMs in IceCube Upgrade
+            rde = frame["I3Calibration"].dom_cal[om_key].relative_dom_eff
+        else:
+            try:
+                rde = self._calibration.dom_cal[om_key].relative_dom_eff
+            except:
+                rde = -1
+        return rde
 
 class I3FeatureExtractorIceCubeDeepCore(I3FeatureExtractorIceCube86):
     """..."""

--- a/src/graphnet/data/i3extractor.py
+++ b/src/graphnet/data/i3extractor.py
@@ -93,7 +93,7 @@ class I3FeatureExtractor(I3Extractor):
                     frame["I3Calibration"] = self._calibration
                     data = frame[self._pulsemap].apply(frame)
                     om_keys = data.keys()
-                    del frame["I3Calibration"]  # Avoid modifying the frame in-place
+                    #del frame["I3Calibration"]  # Avoid modifying the frame in-place
             except:
                 data = dataclasses.I3RecoPulseSeriesMap.from_frame(frame, self._pulsemap)
                 om_keys = data.keys()
@@ -403,12 +403,15 @@ def frame_is_montecarlo(frame):
         frame_has_key(frame, "I3MCTree")
     )
 def frame_is_noise(frame):
-    if frame_has_key(frame, "noise_weight"):
-        return True
-    elif frame_has_key(frame, "NoiseEngine_bool"):
-        return True
-    else:
+    try:
+        frame['I3MCTree'][0].energy
         return False
+    except:
+        try:
+            frame['MCInIcePrimary'].energy
+            return False
+        except:
+            return True
 
 def frame_is_lvl7(frame):
     return frame_has_key(frame, "L7_reconstructed_zenith")


### PR DESCRIPTION
Hi! This contain two changes

1.  Update of `frame_is_noise`
2.  Removal of `del frame["I3Calibration"]  # Avoid modifying the frame in-place`



About 1:
The old version relied on certain i3 keys to determine pure noise events which weren't robust. In fact, a bug related to these fields for a special piece of MC triggered this change.

About 2:
When  removing` frame["I3Calibration"]` we automatically set `rde = -1` for all pulses in that event. (That is never good).  

```
def _get_om_keys_and_pulseseries(self, frame):
        """Gets the indicies for the gcd_dict and the pulse series

        Args:
            frame (i3 physics frame): i3 physics frame

        Returns:
            om_keys (index): the indicies for the gcd_dict
            data    (??)   : the pulse series
        """
        data = frame[self._pulsemap]
        try:
            om_keys = data.keys()
        except:
            try:
                if "I3Calibration" in frame.keys():
                    data = frame[self._pulsemap].apply(frame)
                    om_keys = data.keys()
                else:
                    frame["I3Calibration"] = self._calibration
                    data = frame[self._pulsemap].apply(frame)
                    om_keys = data.keys()
                    #del frame["I3Calibration"]  # Avoid modifying the frame in-place
            except:
                data = dataclasses.I3RecoPulseSeriesMap.from_frame(frame, self._pulsemap)
                om_keys = data.keys()
        return om_keys, data
```
This doesn't seem to be an issue for level7 and level2 and level4 because the logic never makes it to the `else` statement that contains this delete statement. At least that is my theory - I've checked level7 and level2 events and found no `rde= -1` cases. We need to do try-catch of different errors because the way in which the pulses are stored in the i3 frames is not consistent between MC in IceCube. Therefore some sets trigger different logic in the code above. So the `rde = -1` bug only trigger for those cases that ends up in the else-statement. 

I don't think there is any reason why `del frame["I3Calibration"] ` is required, so an easy fix is to remove it. I believe @asogaard  added that delete statement a while back, perhaps you can comment on this?

Rasmus 