### PR TITLE
Pulse noise training

### DIFF
--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -85,36 +85,6 @@ class SQLiteDataset(torch.utils.data.Dataset):
             graph[node_truth_column] = torch.tensor(self._get_node_truth(i, node_truth_column)).reshape(-1)
         return graph
 
-    def _get_node_truth(self, i, node_truth_column):
-        """Query SQLite database for node truth information.
-        """
-        if self._database_list == None:
-            index = self._indices[i]
-        else:
-            index = self._indices[i][0]
-
-        if self._string_selection == None:
-            node_truth = self._conn.execute(
-                "SELECT {} FROM {} WHERE {} = {}".format(
-                    node_truth_column,
-                    self._node_truth_table,
-                    self._index_column,
-                    index,
-                )
-            ).fetchall()
-        else:
-            node_truth = self._conn.execute(
-                "SELECT {} FROM {} WHERE {} = {} and string in {}".format(
-                    node_truth_column,
-                    self._node_truth_table,
-                    self._index_column,
-                    index,
-                    str(tuple(self._string_selection)),
-                )
-            ).fetchall()
-
-        return node_truth
-
     def __getitem__(self, i):
         self.establish_connection(i)
         features, truth = self._query_database(i)

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -15,7 +15,7 @@ class SQLiteDataset(torch.utils.data.Dataset):
         pulsemaps: Union[str, List[str]],
         features: List[str],
         truth: List[str],
-        node_truth: Optional[List[str]] = None,
+        node_truth_column: Optional[List[str]] = None,
         index_column: str = 'event_no',
         truth_table: str = 'truth',
         node_truth_table: Optional[str] = None,
@@ -40,11 +40,11 @@ class SQLiteDataset(torch.utils.data.Dataset):
         assert isinstance(features, (list, tuple))
         assert isinstance(truth, (list, tuple))
 
-        if node_truth != None:
+        if node_truth_column != None:
             assert isinstance(node_truth_table, str)
-            if isinstance(node_truth, str):
-                node_truth = [node_truth]
-            self._node_truth = node_truth
+            if isinstance(node_truth_column, str):
+                node_truth_column = [node_truth_column]
+            self._node_truth_column = node_truth_column
             self._node_truth_table = node_truth_table
 
         if string_selection != None:
@@ -80,7 +80,7 @@ class SQLiteDataset(torch.utils.data.Dataset):
         return len(self._indices)
 
     def _add_node_truth(self, i, graph):
-        for node_truth_column in self._node_truth:
+        for node_truth_column in self._node_truth_column:
             graph[node_truth_column] = torch.tensor(self._get_node_truth(i, node_truth_column)).reshape(-1)
         return graph
 
@@ -118,7 +118,7 @@ class SQLiteDataset(torch.utils.data.Dataset):
         self.establish_connection(i)
         features, truth = self._query_database(i)
         graph = self._create_graph(features, truth)
-        if self._node_truth != None:
+        if self._node_truth_column != None:
             graph = self._add_node_truth(i, graph)
         return graph
 

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -108,7 +108,7 @@ class SQLiteDataset(torch.utils.data.Dataset):
                     self._node_truth_table,
                     self._index_column,
                     index,
-                    self._string_selection,
+                    str(tuple(self._string_selection)),
                 )
             ).fetchall()
 
@@ -161,7 +161,7 @@ class SQLiteDataset(torch.utils.data.Dataset):
                         pulsemap,
                         self._index_column,
                         index,
-                        self._string_selection
+                        str(tuple(self._string_selection))
                     )
                 ).fetchall()
             features.extend(features_pulsemap)

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -88,6 +88,25 @@ class SQLiteDataset(torch.utils.data.Dataset):
             graph[node_truth_column] = torch.tensor(self._get_node_truth(i, node_truth_column)).reshape(-1)
         return graph
 
+def _query_table(self, columns: Union[List, str], table: str, index: int, selection: Optional[Str] = None):
+    """Query a table at a specific index, optionally subject to some selection.""" 
+    # Check(s)
+    if isinstance(columns, list):
+        columns = ', '.join(columns)
+
+    if not selection:  # I.e., `None` or `""`
+        selection = "1=1"  # Identically true, to select all
+    
+    if self._database_list == None:
+        index = self._indices[i]
+    else:
+        index = self._indices[i][0]
+
+    # Query table
+    result = self._conn.execute(
+        f"SELECT {columns} FROM {table} WHERE {self._index_column} = {index} and {selection}"
+    ).fetchall()
+    return result
     def __getitem__(self, i):
         self.establish_connection(i)
         features, truth = self._query_database(i)

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -146,25 +146,22 @@ class SQLiteDataset(torch.utils.data.Dataset):
 
         features = []
         for pulsemap in self._pulsemaps:
-            if self._string_selection == None:
-                features_pulsemap = self._conn.execute(
-                    "SELECT {} FROM {} WHERE {} = {}".format(
-                        self._features_string,
-                        pulsemap,
-                        self._index_column,
-                        index,
-                    )
-                ).fetchall()
+            features_pulsemap = self._query_table(
+                self._features_string,
+                pulsemap,
+                index,
+                self._selection,
+            )
+            
+            if self._node_truth:
+                node_truth = self._query_table(
+                    self._node_truth_string,
+                    self._node_truth_table,
+                    index,
+                    self._selection,
+                )
             else:
-                features_pulsemap = self._conn.execute(
-                    "SELECT {} FROM {} WHERE {} = {} and string in {}".format(
-                        self._features_string,
-                        pulsemap,
-                        self._index_column,
-                        index,
-                        str(tuple(self._string_selection))
-                    )
-                ).fetchall()
+                node_truth = None
             features.extend(features_pulsemap)
 
         truth = self._conn.execute(

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -51,7 +51,7 @@ class SQLiteDataset(torch.utils.data.Dataset):
             print('WARNING - STRING SELECTION DETECTED. \n Accepted strings: %s \n all other strings are ignored!'%string_selection)
             if isinstance(string_selection, int):
                 string_selection = [string_selection]
-            assert isinstance(string_selection, (list))
+            #assert isinstance(string_selection, (list, int))
         
         self._string_selection = string_selection
 

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -55,6 +55,9 @@ class SQLiteDataset(torch.utils.data.Dataset):
                 string_selection = [string_selection]
         
         self._string_selection = string_selection
+        self._selection = ""
+        if self._string_selection:
+            self._selection = f"string in {str(tuple(self._string_selection))}" 
 
         self._database = database
         self._pulsemaps = pulsemaps

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -15,7 +15,7 @@ class SQLiteDataset(torch.utils.data.Dataset):
         pulsemaps: Union[str, List[str]],
         features: List[str],
         truth: List[str],
-        node_truth_column: Optional[List[str]] = None,
+        node_truth: Optional[List[str]] = None,
         index_column: str = 'event_no',
         truth_table: str = 'truth',
         node_truth_table: Optional[str] = None,

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -53,7 +53,6 @@ class SQLiteDataset(torch.utils.data.Dataset):
             print('WARNING - STRING SELECTION DETECTED. \n Accepted strings: %s \n all other strings are ignored!'%string_selection)
             if isinstance(string_selection, int):
                 string_selection = [string_selection]
-            #assert isinstance(string_selection, (list, int))
         
         self._string_selection = string_selection
 

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -83,10 +83,6 @@ class SQLiteDataset(torch.utils.data.Dataset):
     def __len__(self):
         return len(self._indices)
 
-    def _add_node_truth(self, i, graph):
-        for node_truth_column in self._node_truth_column:
-            graph[node_truth_column] = torch.tensor(self._get_node_truth(i, node_truth_column)).reshape(-1)
-        return graph
 
 def _query_table(self, columns: Union[List, str], table: str, index: int, selection: Optional[Str] = None):
     """Query a table at a specific index, optionally subject to some selection.""" 

--- a/src/graphnet/data/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite_dataset.py
@@ -40,12 +40,14 @@ class SQLiteDataset(torch.utils.data.Dataset):
         assert isinstance(features, (list, tuple))
         assert isinstance(truth, (list, tuple))
 
-        if node_truth_column != None:
+        self._node_truth = None
+        if node_truth != None:
             assert isinstance(node_truth_table, str)
-            if isinstance(node_truth_column, str):
-                node_truth_column = [node_truth_column]
-            self._node_truth_column = node_truth_column
+            if isinstance(node_truth, str):
+                node_truth = [node_truth]
+            self._node_truth = node_truth
             self._node_truth_table = node_truth_table
+            self._node_truth_string = ', '.join(self._node_truth)
 
         if string_selection != None:
             print('WARNING - STRING SELECTION DETECTED. \n Accepted strings: %s \n all other strings are ignored!'%string_selection)

--- a/src/graphnet/models/gnn/__init__.py
+++ b/src/graphnet/models/gnn/__init__.py
@@ -1,2 +1,2 @@
-from .dynedge import DynEdge, DynEdge_V2
+from .dynedge import DynEdge, DynEdge_V2, DynEdge_V3
 from .convnet import ConvNet

--- a/src/graphnet/models/gnn/dynedge.py
+++ b/src/graphnet/models/gnn/dynedge.py
@@ -295,3 +295,134 @@ class DynEdge_V2(GNN):
         x = self.lrelu(x)
 
         return x
+
+class DynEdge_V3(GNN):
+    def __init__(self, nb_inputs, layer_size_scale=4):
+        """DynEdge model.
+        Args:
+            nb_inputs (int): Number of input features.
+            nb_outputs (int): Number of output features.
+            layer_size_scale (int, optional): Integer that scales the size of
+                hidden layers. Defaults to 4.
+        """
+
+        # Architecture configuration
+        c = layer_size_scale
+        l1, l2, l3, l4, l5,l6 = nb_inputs * 2 + 5, c*16*2, c*32*2, c*42*2, c*32*2, c*16*2
+
+        # Base class constructor
+        super().__init__(nb_inputs, l6)
+
+        # Graph convolutional operations
+        features_subset = slice(0,3)
+        nb_neighbors = 8
+
+        self.conv_add1 = DynEdgeConv(
+            torch.nn.Sequential(
+                torch.nn.Linear(l1*2, l2),
+                torch.nn.LeakyReLU(),
+                torch.nn.Linear(l2, l3),
+                torch.nn.LeakyReLU(),
+            ),
+            aggr='add',
+            nb_neighbors=nb_neighbors,
+            features_subset=features_subset,
+        )
+
+        self.conv_add2 = DynEdgeConv(
+            torch.nn.Sequential(
+                torch.nn.Linear(l3*2, l4),
+                torch.nn.LeakyReLU(),
+                torch.nn.Linear(l4, l3),
+                torch.nn.LeakyReLU(),
+            ),
+            aggr='add',
+            nb_neighbors=nb_neighbors,
+            features_subset=features_subset,
+        )
+
+        self.conv_add3 = DynEdgeConv(
+            torch.nn.Sequential(
+                torch.nn.Linear(l3*2,l4),
+                torch.nn.LeakyReLU(),
+                torch.nn.Linear(l4, l3),
+                torch.nn.LeakyReLU(),
+            ),
+            aggr='add',
+            nb_neighbors=nb_neighbors,
+            features_subset=features_subset,
+        )
+
+        self.conv_add4 = DynEdgeConv(
+            torch.nn.Sequential(
+                torch.nn.Linear(l3*2,l4),
+                torch.nn.LeakyReLU(),
+                torch.nn.Linear(l4, l3),
+                torch.nn.LeakyReLU(),
+            ),
+            aggr='add',
+            nb_neighbors=nb_neighbors,
+            features_subset=features_subset,
+        )
+
+        # Post-processing operations
+        self.nn1 = torch.nn.Linear(l3*4 + l1,l4)
+        self.nn2 = torch.nn.Linear(l4,l5)
+        #self.nn3 = torch.nn.Linear(3*l5 + 0,l6)  # 4*l5 + 5
+        self.nn3 = torch.nn.Linear(l5,l6)
+        self.lrelu = torch.nn.LeakyReLU()
+
+    def forward(self, data: Data) -> Tensor:
+        """Model forward pass.
+        Args:
+            data (Data): Graph of input features.
+        Returns:
+            Tensor: Model output.
+        """
+
+        # Convenience variables
+        x, edge_index, batch = data.x, data.edge_index, data.batch
+
+        # Calculate homophily (scalar variables)
+        h_x, h_y, h_z, h_t = calculate_xyzt_homophily(x, edge_index, batch)
+
+        # Calculate mean features
+        global_means = scatter_mean(x, batch, dim=0)
+
+        # Add global variables
+        distribute = (batch.unsqueeze(dim=1) == torch.unique(batch).unsqueeze(dim=0)).type(torch.float)
+
+        global_variables = torch.cat([
+            global_means,
+            torch.log10(data.n_pulses).unsqueeze(dim=1),
+            h_x,
+            h_y,
+            h_z,
+            h_t,
+        ], dim=1)
+
+
+        global_variables_distributed = torch.sum(distribute.unsqueeze(dim=2) * global_variables.unsqueeze(dim=0), dim=1)
+
+        x = torch.cat((x, global_variables_distributed), dim=1)
+
+        a, edge_index = self.conv_add1(x, edge_index, batch)
+        b, edge_index = self.conv_add2(a, edge_index, batch)
+        c, edge_index = self.conv_add3(b, edge_index, batch)
+        d, edge_index = self.conv_add4(c, edge_index, batch)
+
+        # Skip-cat
+        x = torch.cat((x, a, b, c, d), dim=1)
+
+        # Post-processing
+        x = self.nn1(x)
+        x = self.lrelu(x)
+        x = self.nn2(x)
+
+        # Read-out
+        x = self.lrelu(x)
+        x = self.nn3(x)
+
+        x = self.lrelu(x)
+
+        return x 

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -41,7 +41,7 @@ def make_dataloader(
         features,
         truth,
         selection=selection,
-        node_truth_column = node_truth_column,
+        node_truth = node_truth,
         node_truth_table = node_truth_table,
         string_selection=string_selection,
     )

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -28,6 +28,7 @@ def make_dataloader(
     persistent_workers: bool = True,
     node_truth_column: str = None,
     node_truth_table: str  = None,
+    string_selection: List[int] = None,
 ) -> DataLoader:
 
     # Check(s)
@@ -42,6 +43,7 @@ def make_dataloader(
         selection=selection,
         node_truth_column = node_truth_column,
         node_truth_table = node_truth_table,
+        string_selection=string_selection,
     )
 
     def collate_fn(graphs):
@@ -76,6 +78,7 @@ def make_train_validation_dataloader(
     persistent_workers: bool = True,
     node_truth_column: str = None,
     node_truth_table: str  = None,
+    string_selection: List[int] = None,
 ) -> Tuple[DataLoader]:
 
     # Reproducibility
@@ -106,6 +109,7 @@ def make_train_validation_dataloader(
         persistent_workers=persistent_workers,
         node_truth_column = node_truth_column,
         node_truth_table = node_truth_table,
+        string_selection = string_selection,
     )
 
     training_dataloader = make_dataloader(

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -76,7 +76,7 @@ def make_train_validation_dataloader(
     test_size: float = 0.33,
     num_workers: int = 10,
     persistent_workers: bool = True,
-    node_truth_column: str = None,
+    node_truth: str = None,
     node_truth_table: str  = None,
     string_selection: List[int] = None,
 ) -> Tuple[DataLoader]:

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -114,7 +114,7 @@ def make_train_validation_dataloader(
 
     return training_dataloader, validation_dataloader  # , {'valid_selection':validation_selection, 'training_selection':training_selection}
 
-def get_predictions(trainer, model, dataloader, prediction_columns, additional_attributes=None):
+def get_predictions(trainer, model, dataloader, prediction_columns, node_level = False, additional_attributes=None):
     # Check(s)
     if additional_attributes is None:
         additional_attributes = []
@@ -138,7 +138,12 @@ def get_predictions(trainer, model, dataloader, prediction_columns, additional_a
     attributes = OrderedDict([(attr, []) for attr in additional_attributes])
     for batch in dataloader:
         for attr in attributes:
-            attributes[attr].extend(batch[attr].detach().cpu().numpy())
+            attribute = batch[attr].detach().cpu().numpy()
+            if node_level == True:
+                if attr == 'event_no':
+                    attribute = np.repeat(attribute, batch['n_pulses'].detach().cpu().numpy())
+            attributes[attr].extend(attribute)
+
 
     data = np.concatenate([predictions] + [
         np.asarray(values)[:, np.newaxis] for values in attributes.values()

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -107,7 +107,7 @@ def make_train_validation_dataloader(
         batch_size=batch_size,
         num_workers=num_workers,
         persistent_workers=persistent_workers,
-        node_truth_column = node_truth_column,
+        node_truth = node_truth,
         node_truth_table = node_truth_table,
         string_selection = string_selection,
     )

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -26,6 +26,8 @@ def make_dataloader(
     selection: List[int] = None,
     num_workers: int = 10,
     persistent_workers: bool = True,
+    node_truth_column: str = None,
+    node_truth_table: str  = None,
 ) -> DataLoader:
 
     # Check(s)
@@ -38,6 +40,8 @@ def make_dataloader(
         features,
         truth,
         selection=selection,
+        node_truth_column = node_truth_column,
+        node_truth_table = node_truth_table,
     )
 
     def collate_fn(graphs):
@@ -70,6 +74,8 @@ def make_train_validation_dataloader(
     test_size: float = 0.33,
     num_workers: int = 10,
     persistent_workers: bool = True,
+    node_truth_column: str = None,
+    node_truth_table: str  = None,
 ) -> Tuple[DataLoader]:
 
     # Reproducibility
@@ -98,6 +104,8 @@ def make_train_validation_dataloader(
         batch_size=batch_size,
         num_workers=num_workers,
         persistent_workers=persistent_workers,
+        node_truth_column = node_truth_column,
+        node_truth_table = node_truth_table,
     )
 
     training_dataloader = make_dataloader(

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -26,7 +26,7 @@ def make_dataloader(
     selection: List[int] = None,
     num_workers: int = 10,
     persistent_workers: bool = True,
-    node_truth_column: str = None,
+    node_truth: str = None,
     node_truth_table: str  = None,
     string_selection: List[int] = None,
 ) -> DataLoader:


### PR DESCRIPTION
This is my take on a 'beautified' version of #182 according to the comment thread.


- Adds functionality to include node-level truth (generalizes to any number of truths from any node truth table)
- Lets the user specify a range of strings (so-called 'string_selection'). If a string selection is made, only pulses seen by DOMs on these strings are returned by the SQLite query.

- `get_predictions_pulse_level` is still ugly. Would like input on how to do this generally @asogaard 

@kaareendrup @MortenHolmRep  fyi