### PR TITLE
Fixed call of get_predictions(...)

### DIFF
--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -127,7 +127,7 @@ def main():
         model,
         validation_dataloader,
         [config["target"] + '_pred'],
-        [config["target"], 'event_no'],
+        additional_attributes=[config["target"], 'event_no'],
     )
 
     save_results(config["db"], run_name, results, archive, model)

--- a/src/graphnet/data/pipeline.py
+++ b/src/graphnet/data/pipeline.py
@@ -94,7 +94,7 @@ class InSQLitePipeline(ABC):
             model = torch.load(self._module_dict[target]['path'], map_location = 'cpu', pickle_module = dill)
             model.eval()
             model.inference()
-            results = get_predictions(trainer,model, dataloader, self._module_dict[target]['output_column_names'], ['event_no'])
+            results = get_predictions(trainer,model, dataloader, self._module_dict[target]['output_column_names'], additional_attributes=['event_no'])
             dataframes.append(results.sort_values('event_no').reset_index(drop = True))
             df = self._combine_outputs(dataframes)
         return df

--- a/src/graphnet/models/training/utils.py
+++ b/src/graphnet/models/training/utils.py
@@ -126,7 +126,7 @@ def make_train_validation_dataloader(
 
     return training_dataloader, validation_dataloader  # , {'valid_selection':validation_selection, 'training_selection':training_selection}
 
-def get_predictions(trainer, model, dataloader, prediction_columns, node_level = False, additional_attributes=None):
+def get_predictions(trainer, model, dataloader, prediction_columns, *, node_level = False, additional_attributes=None):
     # Check(s)
     if additional_attributes is None:
         additional_attributes = []

--- a/studies/upgrade_neutrino_reconstruction/modelling/train_model.py
+++ b/studies/upgrade_neutrino_reconstruction/modelling/train_model.py
@@ -148,7 +148,7 @@ def main():
         model,
         validation_dataloader,
         [config['target'] + '_pred', config['target'] + '_kappa'],
-        [config['target'], 'event_no', 'energy', 'n_pulses'],
+        additional_attributes=[config['target'], 'event_no', 'energy', 'n_pulses'],
     )
 
     save_results(config['db'], run_name, results, archive, model)

--- a/studies/upgrade_noise/modelling/run_jobs.py
+++ b/studies/upgrade_noise/modelling/run_jobs.py
@@ -186,7 +186,7 @@ def predict(model,trainer,target,selection, database, pulsemap, batch_size, num_
         model,
         validation_dataloader,
         [target + '_pred', target + '_kappa'],
-        [target, 'event_no', 'energy'],
+        additional_attributes=[target, 'event_no', 'energy'],
         )
 
     if target in ['track', 'neutrino']:
@@ -201,7 +201,7 @@ def predict(model,trainer,target,selection, database, pulsemap, batch_size, num_
         model,
         validation_dataloader,
         [target + '_pred'],
-        [target, 'event_no', 'energy'],
+        additional_attributes=[target, 'event_no', 'energy'],
     )
 
     if target == 'energy':
@@ -217,7 +217,7 @@ def predict(model,trainer,target,selection, database, pulsemap, batch_size, num_
         model,
         validation_dataloader,
         [target + '_pred'],
-        [target, 'event_no'],
+        additional_attributes=[target, 'event_no'],
         )
     if target == 'XYZ':
         #predictor_valid = Predictor(
@@ -232,7 +232,7 @@ def predict(model,trainer,target,selection, database, pulsemap, batch_size, num_
         model,
         validation_dataloader,
         ['position_x_pred','position_y_pred','position_z_pred'],
-        ['position_x','position_y','position_z', 'event_no', 'energy'],
+        additional_attributes=['position_x','position_y','position_z', 'event_no', 'energy'],
     )
     save_results(database, run_name, results, archive,model)
     return


### PR DESCRIPTION
This fix is needed because the function signature of `get_predictions(...)` was changed recently.

The 'old' signature was:
```python
def get_predictions(trainer, model, dataloader, prediction_columns, additional_attributes=None):
```
But the new one is:
```python
def get_predictions(trainer, model, dataloader, prediction_columns, node_level = False, additional_attributes=None):
```

This problem might likely occur in many places, since `get_predictions` is probably used in many places.
It might make sense to make `additional_attributes` as well as `node_level` kw-only-args in order to produce helpful error messages.

Suggestion:
```python
def get_predictions(trainer, model, dataloader, prediction_columns, *, node_level = False, additional_attributes=None):
```