### PR TITLE
Updating build-icetray action

### DIFF
--- a/.github/actions/install-cpu/action.yml
+++ b/.github/actions/install-cpu/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Whether to install graphnet as editable"
     required: true
     default: false
+  user:
+    description: "Whether to install graphnet as user"
+    required: true
+    default: false
   extras:
     description: "Extras flags for pip installation of graphnet"
     required: true
@@ -16,8 +20,9 @@ runs:
   steps:
     - name: Infer installation flags
       run: |
-        PIP_FLAGS=`[[ ${{ inputs.editable }} =~ (T|t)rue ]] && printf "%s\n" "-e" || echo " "`
-        echo "PIP_FLAGS=${PIP_FLAGS}" >> $GITHUB_ENV
+        PIP_FLAG_EDITABLE=`[[ ${{ inputs.editable }} =~ (T|t)rue ]] && printf "%s\n" "-e " || echo " "`
+        PIP_FLAG_USER=`[[ ${{ inputs.user }} =~ (T|t)rue ]] && printf "%s\n" "--user " || echo " "`
+        echo "PIP_FLAGS=${PIP_FLAG_EDITABLE}${PIP_FLAG_USER}" >> $GITHUB_ENV
       shell: bash
     - name: Install dependencies
       run: |

--- a/.github/actions/install-cpu/action.yml
+++ b/.github/actions/install-cpu/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         PIP_FLAG_EDITABLE=`[[ ${{ inputs.editable }} =~ (T|t)rue ]] && printf "%s\n" "-e " || echo " "`
         PIP_FLAG_USER=`[[ ${{ inputs.user }} =~ (T|t)rue ]] && printf "%s\n" "--user " || echo " "`
-        echo "PIP_FLAGS=${PIP_FLAG_EDITABLE}${PIP_FLAG_USER}" >> $GITHUB_ENV
+        echo "PIP_FLAGS=${PIP_FLAG_USER}${PIP_FLAG_EDITABLE}" >> $GITHUB_ENV
       shell: bash
     - name: Install dependencies
       run: |
@@ -31,5 +31,5 @@ runs:
       shell: bash
     - name: Install package
       run: |
-        pip install ${{ env.PIP_FLAGS }} -r requirements/torch_cpu.txt .${{ inputs.extras }}
+        pip install -r requirements/torch_cpu.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
       shell: bash

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -25,10 +25,10 @@ jobs:
         uses: ./.github/actions/install-cpu
         with:
           editable: true
-          user: true
+          user: false
       - name: Upgrade astropy, already installed on icecube/icetray [https://github.com/astropy/astropy/issues/12534]
         run: |
-          pip install --user --upgrade astropy
+          pip install --upgrade astropy
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV
+          echo "CC_TEST_REPORTER_ID=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV
       - name: Retrieve test data
         if: "${{ env.PUB_WISC_USERNAME != '' }}"
         run: |
@@ -64,7 +65,7 @@ jobs:
           git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
-        if: "${{ env.CC_TEST_REPORTER_ID != '' }} && ${{ env.PUB_WISC_USERNAME != '' }}"
+        if: "${{ (env.PUB_WISC_USERNAME != '') && (env.CC_TEST_REPORTER_ID != '') }}"
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
         with:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -28,7 +28,6 @@ jobs:
         uses: ./.github/actions/install-cpu
         with:
           editable: true
-          user: true
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Check secrets
         id: setvar
         run: |
-         if [[ "${{ secrets.PUB_WISC_USERNAME }}" != "" && \
+         if [[ "${{ secrets.PUB_WISC_HOST }}" != "" && \
+               "${{ secrets.PUB_WISC_USERNAME }}" != "" && \
                "${{ secrets.PUB_WISC_PASSWORD }}" != "" ]]; \
          then
            echo "Credentials to access Cobalt found"
@@ -64,10 +65,6 @@ jobs:
         uses: ./.github/actions/install-cpu
         with:
           editable: true
-      - name: Check secrets
-        run: |
-          echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV
-          echo "CC_TEST_REPORTER_ID=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV
       - name: Retrieve test data
         run: |
           # Create test data directory

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Install package
         uses: ./.github/actions/install-cpu
         with:
-          editable: false
+          editable: true
+          user: true
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -13,8 +13,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+
   check-cobalt-credentials:
-    description: Check if Cobalt credentials were set on secrets
     runs-on: ubuntu-latest
     outputs:
       has-credentials: ${{ steps.setvar.outputs.has-credentials }}
@@ -25,14 +25,30 @@ jobs:
                "${{ secrets.PUB_WISC_PASSWORD }}" != "" ]]; \
          then
            echo "Credentials to access Cobalt found"
-           echo "::set-output name=has_credentials::true"
+           echo "::set-output name=has-credentials::true"
          else
            echo "Credentials to access Cobalt not found"
-           echo "::set-output name=has_credentials::false"
+           echo "::set-output name=has-credentials::false"
+         fi
+
+  check-codeclimate-credentials:
+    runs-on: ubuntu-latest
+    outputs:
+      has-credentials: ${{ steps.setvar.outputs.has-credentials }}
+    steps:
+      - name: Check secrets
+        run: |
+         if [[ "${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}" != "" ]]; \
+         then
+           echo "Credentials to access CodeClimate found"
+           echo "::set-output name=has-credentials::true"
+         else
+           echo "Credentials to access CodeClimate not found"
+           echo "::set-output name=has-credentials::false"
          fi
 
   build-icetray:
-    needs: [ check-cobalt-credentials ]
+    needs: [ check-cobalt-credentials, check-codeclimate-credentials ]
     if: ${{ needs.check-cobalt-credentials.outputs.has-credentials == 'true' }}
     runs-on: ubuntu-latest
     container: icecube/icetray:combo-stable
@@ -85,7 +101,7 @@ jobs:
           git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
-        if: "${{ (env.PUB_WISC_USERNAME != '') && (env.CC_TEST_REPORTER_ID != '') }}"
+        if: ${{ needs.check-codeclimate-credentials.outputs.has-credentials == 'true' }}
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
         with:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -26,9 +26,10 @@ jobs:
         with:
           editable: true
           user: false
-      - name: Upgrade astropy, already installed on icecube/icetray [https://github.com/astropy/astropy/issues/12534]
+      - name: Upgrade packages already installed on icecube/icetray
         run: |
-          pip install --upgrade astropy
+          pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
+          pip install --ignore-installed PyYAML  # Distutils installed [https://github.com/pypa/pip/issues/5247]
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -18,14 +18,7 @@ jobs:
     container: icecube/icetray:combo-stable
     steps:
       - uses: actions/checkout@v2
-      - name: Debug
-        run: |
-          pwd
-          ls -lart .
-          ls -lart requirements/
-          ls -lart requirements/torch_cpu.txt
-          pip list
-      - name: Update PATH
+      - name: Update PATH to make scripts available, since we're installing graphnet as user
         run: |
           echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
       - name: Install package

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -24,10 +24,14 @@ jobs:
           ls -lart .
           ls -lart requirements/
           ls -lart requirements/torch_cpu.txt
+      - name: Update PATH
+        run: |
+          echo "PATH=~/.local/bin:$PATH" >> $GITHUB_ENV
       - name: Install package
         uses: ./.github/actions/install-cpu
         with:
           editable: true
+          user: true
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -26,12 +26,15 @@ jobs:
           ls -lart requirements/torch_cpu.txt
       - name: Update PATH
         run: |
-          echo "PATH=~/.local/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
       - name: Install package
         uses: ./.github/actions/install-cpu
         with:
           editable: true
           user: true
+      - name: Debug
+        run: |
+          ls -lart $HOME/.local/bin
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install package
         uses: ./.github/actions/install-cpu
         with:
-          editable: true
+          editable: false
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -21,15 +21,15 @@ jobs:
       - name: Update PATH to make scripts available, since we're installing graphnet as user
         run: |
           echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
+      - name: Upgrade packages already installed on icecube/icetray
+        run: |
+          pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
+          pip install --ignore-installed PyYAML  # Distutils installed [https://github.com/pypa/pip/issues/5247]
       - name: Install package
         uses: ./.github/actions/install-cpu
         with:
           editable: true
           user: false
-      - name: Upgrade packages already installed on icecube/icetray
-        run: |
-          pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
-          pip install --ignore-installed PyYAML  # Distutils installed [https://github.com/pypa/pip/issues/5247]
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -22,6 +22,8 @@ jobs:
         run: |
           pwd
           ls -lart .
+          ls -lart requirements/
+          ls -lart requirements/torch_cpu.txt
       - name: Install package
         uses: ./.github/actions/install-cpu
         with:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -17,7 +17,7 @@ jobs:
   check-cobalt-credentials:
     runs-on: ubuntu-latest
     outputs:
-      has-credentials: ${{ steps.setvar.outputs.has-credentials }}
+      has_credentials: ${{ steps.setvar.outputs.has_credentials }}
     steps:
       - name: Check secrets
         run: |
@@ -25,31 +25,31 @@ jobs:
                "${{ secrets.PUB_WISC_PASSWORD }}" != "" ]]; \
          then
            echo "Credentials to access Cobalt found"
-           echo "::set-output name=has-credentials::true"
+           echo "::set-output name=has_credentials::true"
          else
            echo "Credentials to access Cobalt not found"
-           echo "::set-output name=has-credentials::false"
+           echo "::set-output name=has_credentials::false"
          fi
 
   check-codeclimate-credentials:
     runs-on: ubuntu-latest
     outputs:
-      has-credentials: ${{ steps.setvar.outputs.has-credentials }}
+      has_credentials: ${{ steps.setvar.outputs.has_credentials }}
     steps:
       - name: Check secrets
         run: |
          if [[ "${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}" != "" ]]; \
          then
            echo "Credentials to access CodeClimate found"
-           echo "::set-output name=has-credentials::true"
+           echo "::set-output name=has_credentials::true"
          else
            echo "Credentials to access CodeClimate not found"
-           echo "::set-output name=has-credentials::false"
+           echo "::set-output name=has_credentials::false"
          fi
 
   build-icetray:
     needs: [ check-cobalt-credentials, check-codeclimate-credentials ]
-    if: needs.check-cobalt-credentials.outputs.has-credentials == 'true'
+    if: needs.check-cobalt-credentials.outputs.has_credentials == 'true'
     runs-on: ubuntu-latest
     container: icecube/icetray:combo-stable
     steps:
@@ -98,7 +98,7 @@ jobs:
           git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
-        if: needs.check-codeclimate-credentials.outputs.has-credentials == 'true'
+        if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
         with:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -20,6 +20,7 @@ jobs:
       has_credentials: ${{ steps.setvar.outputs.has_credentials }}
     steps:
       - name: Check secrets
+        id: setvar
         run: |
          if [[ "${{ secrets.PUB_WISC_USERNAME }}" != "" && \
                "${{ secrets.PUB_WISC_PASSWORD }}" != "" ]]; \
@@ -37,6 +38,7 @@ jobs:
       has_credentials: ${{ steps.setvar.outputs.has_credentials }}
     steps:
       - name: Check secrets
+        id: setvar
         run: |
          if [[ "${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}" != "" ]]; \
          then

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -13,7 +13,27 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  has-cobalt-credentials:
+    name: Check if Cobalt credentials were set on secrets
+    runs-on: ubuntu-latest
+    outputs:
+      has_credentials: ${{ steps.setvar.outputs.has_credentials }}
+    steps:
+      - id: setvar
+        run: |
+         if [[ "${{ secrets.PUB_WISC_USERNAME }}" != "" && \
+               "${{ secrets.secrets.PUB_WISC_PASSWORD }}" != "" ]]; \
+         then
+           echo "Credentials to access Cobalt found"
+           echo "::set-output name=has_credentials::true"
+         else
+           echo "Credentials to access Cobalt not found"
+           echo "::set-output name=has_credentials::false"
+         fi
+
   build-icetray:
+    needs: [ has-cobalt-credentials ]
+    if: ${{ needs.has-cobalt-credentials.outputs.has_credentials == 'true' }}
     runs-on: ubuntu-latest
     container: icecube/icetray:combo-stable
     steps:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -49,7 +49,7 @@ jobs:
 
   build-icetray:
     needs: [ check-cobalt-credentials, check-codeclimate-credentials ]
-    if: ${{ needs.check-cobalt-credentials.outputs.has-credentials == 'true' }}
+    if: needs.check-cobalt-credentials.outputs.has-credentials == 'true'
     runs-on: ubuntu-latest
     container: icecube/icetray:combo-stable
     steps:
@@ -67,7 +67,6 @@ jobs:
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV
           echo "CC_TEST_REPORTER_ID=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV
       - name: Retrieve test data
-        if: "${{ env.PUB_WISC_USERNAME != '' }}"
         run: |
           # Create test data directory
           mkdir -p $TEST_DATA_DIR
@@ -91,17 +90,15 @@ jobs:
           MD5HASH: 80006a6d58338eb8ea153d2b7b02c0a1
         shell: bash
       - name: Run unit tests and generate coverage report
-        if: "${{ env.PUB_WISC_USERNAME != '' }}"
         run: |
           coverage run --source=graphnet -m pytest tests/
           coverage xml -o coverage.xml
       - name: Work around permission issue
-        if: "${{ env.PUB_WISC_USERNAME != '' }}"
         run: |
           git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
-        if: ${{ needs.check-codeclimate-credentials.outputs.has-credentials == 'true' }}
+        if: needs.check-codeclimate-credentials.outputs.has-credentials == 'true'
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
         with:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -18,6 +18,10 @@ jobs:
     container: icecube/icetray:combo-stable
     steps:
       - uses: actions/checkout@v2
+      - name: Debug
+        run: |
+          pwd
+          ls -lart .
       - name: Install package
         uses: ./.github/actions/install-cpu
         with:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -13,16 +13,16 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  has-cobalt-credentials:
-    name: Check if Cobalt credentials were set on secrets
+  check-cobalt-credentials:
+    description: Check if Cobalt credentials were set on secrets
     runs-on: ubuntu-latest
     outputs:
-      has_credentials: ${{ steps.setvar.outputs.has_credentials }}
+      has-credentials: ${{ steps.setvar.outputs.has-credentials }}
     steps:
-      - id: setvar
+      - name: Check secrets
         run: |
          if [[ "${{ secrets.PUB_WISC_USERNAME }}" != "" && \
-               "${{ secrets.secrets.PUB_WISC_PASSWORD }}" != "" ]]; \
+               "${{ secrets.PUB_WISC_PASSWORD }}" != "" ]]; \
          then
            echo "Credentials to access Cobalt found"
            echo "::set-output name=has_credentials::true"
@@ -32,8 +32,8 @@ jobs:
          fi
 
   build-icetray:
-    needs: [ has-cobalt-credentials ]
-    if: ${{ needs.has-cobalt-credentials.outputs.has_credentials == 'true' }}
+    needs: [ check-cobalt-credentials ]
+    if: ${{ needs.check-cobalt-credentials.outputs.has-credentials == 'true' }}
     runs-on: ubuntu-latest
     container: icecube/icetray:combo-stable
     steps:

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -24,6 +24,7 @@ jobs:
           ls -lart .
           ls -lart requirements/
           ls -lart requirements/torch_cpu.txt
+          pip list
       - name: Update PATH
         run: |
           echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
@@ -32,9 +33,9 @@ jobs:
         with:
           editable: true
           user: true
-      - name: Debug
+      - name: Upgrade astropy, already installed on icecube/icetray [https://github.com/astropy/astropy/issues/12534]
         run: |
-          ls -lart $HOME/.local/bin
+          pip install --user --upgrade astropy
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build-icetray.yml
+++ b/.github/workflows/build-icetray.yml
@@ -18,9 +18,6 @@ jobs:
     container: icecube/icetray:combo-stable
     steps:
       - uses: actions/checkout@v2
-      - name: Update PATH to make scripts available, since we're installing graphnet as user
-        run: |
-          echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
@@ -29,7 +26,6 @@ jobs:
         uses: ./.github/actions/install-cpu
         with:
           editable: true
-          user: false
       - name: Check secrets
         run: |
           echo "PUB_WISC_USERNAME=${{ secrets.PUB_WISC_USERNAME }}" >> $GITHUB_ENV


### PR DESCRIPTION
Following #212 the `build-icetray` action fails, which wasn't caught during the automated testing as the jobs were run against the code in `main` (in order to have access to repository secrets) rather than the code in the feature branch. This PR aims to (1) fix the error that caused the build job to fail and (2) update the action itself to make it run against at the proposed code and to make it clear whether the `build-icetray` action is meaningfully run or not.

* Changes the order of requirements and editable flags for `pip install`
* Updates the `astropy` and `PyYAML` packages on `icecube/icetray` that otherwise yield conflicts during installation
* Make all of `build-icetray` conditional on the existence for Cobalt credentials stored as action secrets, to make it clear when it is being skipped and when it isn't.