### PR TITLE
Mitigate soft_unicode error in docs by limiting MarkupSafe version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ EXTRAS_REQUIRE = {
         "black",
         "colorlog",
         "coverage",
+        "MarkupSafe<=2.1",
         "pre-commit",
         "pydocstyle",
         "pylint",


### PR DESCRIPTION
`docs` job failed on latest PR merge to main