### PR TITLE
Restrict docker to icecube/graphnet

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   docker:
+    if: github.repository == 'icecube/graphnet'
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
Don't publish docker images when pushing to forks' `main` branch.