### PR TITLE
Optimise coarsening

### DIFF
--- a/src/graphnet/components/pool.py
+++ b/src/graphnet/components/pool.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 import torch
 from torch import LongTensor, Tensor
@@ -62,11 +62,11 @@ def _group_identical(
             identical rows to the same group.
     """
     if batch is not None:
-        tensor = tensor.cat((tensor, batch.unsqueeze(dim=1)), dim=1)
-    return torch.unique(tensor, return_inverse=True, dim=0)[1]
+        tensor = torch.cat((batch.unsqueeze(dim=1), tensor), dim=1)
+    return torch.unique(tensor, return_inverse=True, sorted=False, dim=0)[1]
 
 
-def group_by(data: Data, keys: List[str]) -> LongTensor:
+def group_by(data: Union[Data, Batch], keys: List[str]) -> LongTensor:
     """Group nodes in `data` that have identical values of `keys`.
 
     This grouping is done with in each event in case of batching. This allows
@@ -86,7 +86,7 @@ def group_by(data: Data, keys: List[str]) -> LongTensor:
     """
     features = [getattr(data, key) for key in keys]
     tensor = torch.stack(features).T  # .int()  @TODO: Required? Use rounding?
-    batch = getattr(tensor, "batch", None)
+    batch = getattr(data, "batch", None)
     index = _group_identical(tensor, batch)
     return index
 

--- a/src/graphnet/models/detector/detector.py
+++ b/src/graphnet/models/detector/detector.py
@@ -15,12 +15,10 @@ from torch_geometric.data import Data
 from torch_geometric.data.batch import Batch
 
 from graphnet.models.graph_builders import GraphBuilder
-from graphnet.utilities.logging import get_logger
-
-logger = get_logger()
+from graphnet.utilities.logging import LoggerMixin
 
 
-class Detector(LightningModule):
+class Detector(LoggerMixin, LightningModule):
     """Base class for all detector-specific read-ins in graphnet."""
 
     @property
@@ -38,7 +36,7 @@ class Detector(LightningModule):
         self._graph_builder = graph_builder
         self._scalers = scalers
         if self._scalers:
-            logger.info(
+            self.logger.info(
                 (
                     "Will use scalers rather than standard preprocessing "
                     f"in {self.__class__.__name__}.",
@@ -98,9 +96,9 @@ class Detector(LightningModule):
 
     def _validate_features(self, data: Data):
         if isinstance(data, Batch):
-            data_features = data[0].features
+            data_features = [features[0] for features in data.features]
         else:
             data_features = data.features
         assert (
             data_features == self.features
-        ), "Features on Data and Detector differ: {data_features} vs. {self.features}"
+        ), f"Features on Data and Detector differ: {data_features} vs. {self.features}"

--- a/src/graphnet/models/graph_builders.py
+++ b/src/graphnet/models/graph_builders.py
@@ -6,13 +6,10 @@ from torch_geometric.nn import knn_graph, radius_graph
 from torch_geometric.data import Data
 
 from graphnet.models.utils import calculate_distance_matrix
-from graphnet.utilities.logging import get_logger
+from graphnet.utilities.logging import LoggerMixin
 
 
-logger = get_logger()
-
-
-class GraphBuilder(ABC):  # pylint: disable=too-few-public-methods
+class GraphBuilder(LoggerMixin, ABC):  # pylint: disable=too-few-public-methods
     @abstractmethod
     def __call__(self, data: Data) -> Data:
         pass
@@ -39,7 +36,7 @@ class KNNGraphBuilder(GraphBuilder):  # pylint: disable=too-few-public-methods
     def __call__(self, data: Data) -> Data:
         # Constructs the adjacency matrix from the raw, DOM-level data and returns this matrix
         if data.edge_index is not None:
-            logger.info(
+            self.logger.info(
                 (
                     "WARNING: GraphBuilder received graph with pre-existing structure. "
                     "Will overwrite.",
@@ -76,7 +73,7 @@ class RadialGraphBuilder(GraphBuilder):
     def __call__(self, data: Data) -> Data:
         # Constructs the adjacency matrix from the raw, DOM-level data and returns this matrix
         if data.edge_index is not None:
-            logger.info(
+            self.logger.info(
                 (
                     "WARNING: GraphBuilder received graph with pre-existing structure. "
                     "Will overwrite.",
@@ -115,7 +112,7 @@ class EuclideanGraphBuilder(
     def __call__(self, data: Data) -> Data:
         # Constructs the adjacency matrix from the raw, DOM-level data and returns this matrix
         if data.edge_index is not None:
-            logger.info(
+            self.logger.info(
                 (
                     "WARNING: GraphBuilder received graph with pre-existing structure. "
                     "Will overwrite.",


### PR DESCRIPTION
#245 made coarsening work as part of a `graphnet.Model` but was very slow as it relied on splitting batches into events, coarsening these separately, and then recombining them. This PR should make the coarsening work natively on instances of both `Batch` and `Data` with identical results as previously, but radically faster.