### PR TITLE
Properly negate Data.x for min-pooling

### DIFF
--- a/src/graphnet/components/pool.py
+++ b/src/graphnet/components/pool.py
@@ -16,16 +16,20 @@ from torch_geometric.nn.pool import (
 
 
 def min_pool(cluster: Any, data: Any, transform: Optional[Any] = None):
-    """Like `max_pool, just negating `data`."""
-    return -max_pool(
+    """Like `max_pool, just negating `data.x`."""
+    data.x = -data.x
+    data_pooled = max_pool(
         cluster,
-        -data,
+        data,
         transform,
     )
+    data.x = -data.x
+    data_pooled.x = -data_pooled.x
+    return data_pooled
 
 
 def min_pool_x(cluster: Any, x: Any, batch: Any, size: Optional[int] = None):
-    """Like `max_pool_x, just negating `data`."""
+    """Like `max_pool_x, just negating `x`."""
     ret = max_pool_x(cluster, -x, batch, size)
     if size is None:
         return (-ret[0], ret[1])


### PR DESCRIPTION
Negates `Data.x` rather than `Data` (not defined) in `min_pool` when calling `max_pool`.

Closes #251 