### PR TITLE
Tweaks to improve experience with specified package versions

### DIFF
--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -54,7 +54,8 @@ def main():
         "pulsemap": "SRTTWOfflinePulsesDC",
         "batch_size": 512,
         "num_workers": 10,
-        "gpus": [1],
+        "accelerator": "gpu",
+        "devices": [0],
         "target": "energy",
         "n_epochs": 5,
         "patience": 5,
@@ -125,7 +126,8 @@ def main():
     ]
 
     trainer = Trainer(
-        gpus=config["gpus"],
+        accelerator=config["accelerator"],
+        devices=config["devices"],
         max_epochs=config["n_epochs"],
         callbacks=callbacks,
         log_every_n_steps=1,

--- a/requirements/torch_cpu.txt
+++ b/requirements/torch_cpu.txt
@@ -4,5 +4,4 @@ torch==1.11+cpu
 torch-cluster==1.6.0
 torch_scatter==2.0.9
 torch-sparse==0.6.13
-torch-spline-conv==1.2.1
 torch_geometric==2.0.4

--- a/requirements/torch_gpu.txt
+++ b/requirements/torch_gpu.txt
@@ -5,5 +5,4 @@ torch==1.11+cu115
 torch-cluster==1.6.0
 torch_scatter==2.0.9
 torch-sparse==0.6.13
-torch-spline-conv==1.2.1
 torch_geometric==2.0.4

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,11 @@ EXTRAS_REQUIRE = {
         "versioneer",
     ],
     "torch": [
-        "torch==1.11",
-        "torch-cluster==1.6.0",
-        "torch-scatter==2.0.9",
-        "torch-sparse==0.6.13",
-        "torch-spline-conv==1.2.1",
-        "torch-geometric==2.0.4",
+        "torch>=1.11",
+        "torch-cluster>=1.6",
+        "torch-scatter>=2.0",
+        "torch-sparse>=0.6",
+        "torch-geometric>=2.0",
         "pytorch-lightning>=1.6",
     ],
 }

--- a/src/graphnet/data/pipeline.py
+++ b/src/graphnet/data/pipeline.py
@@ -135,7 +135,7 @@ class InSQLitePipeline(ABC):
         dataframes = []
         for target in self._module_dict.keys():
             # dataloader = iter(dataloader)
-            trainer = Trainer(gpus=[device])
+            trainer = Trainer(devices=[device], accelerator="gpu")
             model = torch.load(
                 self._module_dict[target]["path"],
                 map_location="cpu",

--- a/src/graphnet/models/training/callbacks.py
+++ b/src/graphnet/models/training/callbacks.py
@@ -1,7 +1,10 @@
+import logging
+import sys
 import numpy as np
 import torch
 import warnings
 
+from tqdm import tqdm
 from torch.optim.lr_scheduler import _LRScheduler
 from pytorch_lightning.callbacks import TQDMProgressBar
 
@@ -113,3 +116,15 @@ class ProgressBar(TQDMProgressBar):
         self.main_progress_bar.set_description(
             f"Epoch {trainer.current_epoch:2d}"
         )
+
+    def on_train_epoch_end(self, trainer, model):
+        super().on_train_epoch_end(trainer, model)
+
+        # Log the final progress bar for the epoch to file (and don't duplciate
+        # to stdout).
+        h = logger.logger.handlers[0]
+        assert isinstance(h, logging.StreamHandler)
+        level = h.level
+        h.setLevel(logging.ERROR)
+        logger.info(str(super().main_progress_bar))
+        h.setLevel(level)

--- a/src/graphnet/models/training/callbacks.py
+++ b/src/graphnet/models/training/callbacks.py
@@ -105,7 +105,6 @@ class ProgressBar(TQDMProgressBar):
         to overwrite the progress bar from previous epochs.
         """
         if trainer.current_epoch > 0:
-            self._update_bar(self.main_progress_bar)
             self.main_progress_bar.set_postfix(
                 self.get_metrics(trainer, model)
             )

--- a/src/graphnet/models/training/callbacks.py
+++ b/src/graphnet/models/training/callbacks.py
@@ -1,10 +1,7 @@
 import logging
-import sys
 import numpy as np
-import torch
 import warnings
 
-from tqdm import tqdm
 from torch.optim.lr_scheduler import _LRScheduler
 from pytorch_lightning.callbacks import TQDMProgressBar
 

--- a/src/graphnet/utilities/logging.py
+++ b/src/graphnet/utilities/logging.py
@@ -89,7 +89,7 @@ def get_logger(
     if level is None:
         level = logging.INFO
 
-    basic_formatter, colored_formatter = get_formatters()
+    _, colored_formatter = get_formatters()
 
     # Create logger
     logger = colorlog.getLogger(LOGGER_NAME)
@@ -117,13 +117,18 @@ def get_logger(
 
     file_handler = logging.FileHandler(log_path)
     stream_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(basic_formatter)
+    file_handler.setFormatter(colored_formatter)
     logger.addHandler(file_handler)
 
     # Make className empty by default
     logger = logging.LoggerAdapter(logger, extra={"className": ""})
 
-    logger.info(f"Writing log to {log_path}")
+    logger.info(f"Writing log to \033[1m{log_path}\033[0m")
+
+    # Have pytorch lightning write to same log file
+    pl_logger = logging.getLogger("pytorch_lightning")
+    pl_file_handler = logging.FileHandler(log_path)
+    pl_logger.addHandler(pl_file_handler)
 
     # Store as global variable
     LOGGER = logger

--- a/studies/upgrade_neutrino_reconstruction/modelling/train_model.py
+++ b/studies/upgrade_neutrino_reconstruction/modelling/train_model.py
@@ -59,7 +59,8 @@ config = {
     ],
     "batch_size": 256,
     "num_workers": 30,
-    "gpus": [1],
+    "accelerator": "gpu",
+    "devices": [1],
     "target": "zenith",
     "n_epochs": 50,
     "patience": 5,
@@ -145,7 +146,8 @@ def main():
 
     trainer = Trainer(
         default_root_dir=archive,
-        gpus=config["gpus"],
+        accelerator=config["accelerator"],
+        devices=config["devices"],
         max_epochs=config["n_epochs"],
         callbacks=callbacks,
         log_every_n_steps=1,

--- a/studies/upgrade_nmo_sensitivity/modelling/train_model.py
+++ b/studies/upgrade_nmo_sensitivity/modelling/train_model.py
@@ -67,7 +67,8 @@ def main(target: str):
         ],
         "batch_size": 256,
         "num_workers": 30,
-        "gpus": [0],
+        "accelerator": "gpu",
+        "devices": [0],
         "target": target,
         "n_epochs": 50,
         "patience": 5,
@@ -182,7 +183,8 @@ def main(target: str):
 
     trainer = Trainer(
         default_root_dir=archive,
-        gpus=config["gpus"],
+        accelerator=config["accelerator"],
+        devices=config["devices"],
         max_epochs=config["n_epochs"],
         callbacks=callbacks,
         log_every_n_steps=1,


### PR DESCRIPTION
* Removes `torch-spline-conv` from setup and requirements file, as this is currently not used and has led to some annoying issues with setup (see #260)
* Updates this arguments to `Trainer` from `gpus=...` to `accelerator="gpu", devices=...`, since the current syntax yields a deprecation warning for the version of pytorch-lightning specified in the requirements file.
* Prints training history, and some pytorch-lightning outputs, to the log file.

Closes #260 

cc @Aske-Rosted